### PR TITLE
Fix incorrect routes annotations

### DIFF
--- a/shopping-cart/js-shopping-cart/shoppingcart.proto
+++ b/shopping-cart/js-shopping-cart/shoppingcart.proto
@@ -39,19 +39,19 @@ message Cart {
 service ShoppingCart {
     rpc AddItem(AddLineItem) returns (google.protobuf.Empty) {
         option (google.api.http) = {
-            post: "/cart/{user_id}/items/add",
+            post: "/com.example.shoppingcart.ShoppingCart/cart/{user_id}/items/add",
             body: "*",
         };
         option (.cloudstate.eventing).in = "items";
     }
 
     rpc RemoveItem(RemoveLineItem) returns (google.protobuf.Empty) {
-        option (google.api.http).post = "/cart/{user_id}/items/{product_id}/remove";
+        option (google.api.http).post = "/com.example.shoppingcart.ShoppingCart/cart/{user_id}/items/{product_id}/remove";
     }
 
     rpc GetCart(GetShoppingCart) returns (Cart) {
         option (google.api.http) = {
-          get: "/carts/{user_id}",
+          get: "/com.example.shoppingcart.ShoppingCart/carts/{user_id}",
           additional_bindings: {
             get: "/carts/{user_id}/items",
             response_body: "items"
@@ -59,3 +59,4 @@ service ShoppingCart {
         };
     }
 }
+


### PR DESCRIPTION
Fixes #245.

This fix adjusts the google annotation paths in the service def proto file.  They now all include the prefix `com.example.shoppingcart.ShoppingCart`.  This is the prefix that is defined in the routes.yaml for deploying the route.  

Route paths are only ever forwarded and not "appended".  So anything down stream will need to match on the entire route.