### PR TITLE
Docker fixes

### DIFF
--- a/shopping-cart/js-shopping-cart/.dockerignore
+++ b/shopping-cart/js-shopping-cart/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+user-function.desc

--- a/shopping-cart/js-shopping-cart/Dockerfile
+++ b/shopping-cart/js-shopping-cart/Dockerfile
@@ -1,15 +1,13 @@
 FROM node:8.15
 # Copy and install deps. This is done as a separate step as an optimization, so changes to the programs files
 # don't require the npm install to be redone
-RUN mkdir -p /opt/samples/js-shopping-cart
-RUN mkdir -p /opt/samples/js-shopping-cart/protocols/example
-#COPY node-support /opt/node-support
-COPY package.json /opt/samples/js-shopping-cart/
-RUN cd /opt/samples/js-shopping-cart && npm install
+RUN mkdir -p /opt/js-shopping-cart
+COPY package.json /opt/js-shopping-cart/
+WORKDIR /opt/js-shopping-cart
+RUN npm install
 # Now copy the entire app
-COPY . /opt/samples/js-shopping-cart
-WORKDIR /opt/samples/js-shopping-cart
-#RUN npm run prestart  # CA - TODO: this is giving a proto problem (will circle back to deal)
+COPY . /opt/js-shopping-cart
+RUN npm run prestart
 # run
 EXPOSE 8080
 CMD ["npm", "run", "start-no-prestart"]

--- a/shopping-cart/js-shopping-cart/package.json
+++ b/shopping-cart/js-shopping-cart/package.json
@@ -39,7 +39,7 @@
     "pretest": "compile-descriptor ./shoppingcart.proto",
     "start": "node index.js",
     "start-no-prestart": "node index.js",
-    "dockerbuild": "docker build -f ./Dockerfile -t ${DOCKER_PUBLISH_TO:-cloudstateio}/js-shopping-cart:latest ../..",
+    "dockerbuild": "docker build -t ${DOCKER_PUBLISH_TO:-cloudstateio}/js-shopping-cart:latest .",
     "dockerpush": "docker push ${DOCKER_PUBLISH_TO:-cloudstateio}/js-shopping-cart:latest",
     "dockerbuildpush": "npm run dockerbuild && npm run dockerpush"
   }


### PR DESCRIPTION
Fixes a number of issues with the docker build, including:

* node_modules was being included in the build context, making it 111mb instead of 25kb.
* the locally installed node_modules was overwriting the modules installed by an earlier step in this build. This probably caused two problems:
  - OSX users would have already downloaded the Darwin build of protoc, which is why running npm run prestart (ie, precompiling the protobuf descriptor) would fail for them, because the build probably saw protoc already there and so didn't re download it, not realising that it was the Darwin build no the Linux build needed by the Docker container.
  - Linux users may have had problems since node gyp I think is architecture aware, but it may have seen that grpc was already compiled for Linux, and so not recompiled it. This may have caused issues if the versions of Linux libraries running in the container didn't match the versions on the host machine.